### PR TITLE
feat: Make compatible with duckdb 0.7

### DIFF
--- a/aioduckdb/result.py
+++ b/aioduckdb/result.py
@@ -1,13 +1,20 @@
 import duckdb
 from typing import Any, AsyncIterator, Iterable, Optional, Tuple, TYPE_CHECKING, Union
 
+# in DuckDB <0.7.0 there was a separate type, DuckDBPyResult, for a result.
+# In >=0.7.0, that was removed, there is only DuckDBPyConnection
+try:
+    from duckdb import DuckDBPyResult as DuckDBResult
+except ImportError:
+    from duckdb import DuckDBPyConnection as DuckDBResult
+
 if TYPE_CHECKING:
     from .core import Connection
     import pyarrow
     import pandas
 
 class Result:
-    def __init__(self, conn: "Connection", result: duckdb.DuckDBPyResult) -> None:
+    def __init__(self, conn: "Connection", result: DuckDBResult) -> None:
         self.result = result
         self._conn = conn
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ author-email = "darkfm@vera.com.uy"
 description-file = "README.rst"
 home-page = "https://github.com/kouta-kun/aioduckdb"
 requires = [
+    "duckdb",
     "typing_extensions >= 4.0; python_version < '3.8'",
 ]
 requires-python = ">=3.6"


### PR DESCRIPTION
In version 0.7, duckdb removed DuckDBResult, merging it with DuckDBPyConnection. Now this lib works with duckdb >=0.7
